### PR TITLE
Reduce frequency of API calls

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,4 +18,4 @@ jobs:
       - run: npm ci
       - run: npm install --global --no-optional homey
       - run: npm run build
-      - run: homey app validate
+      - run: npm run test

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -26,5 +26,11 @@
     "name": "Chris ter Beke",
     "email": "contact+homey@christerbeke.com"
   },
-  "brandColor": "#f37321"
+  "brandColor": "#f37321",
+  "source": "https://github.com/ChrisTerBeke/homey-enphase",
+  "support": "https://github.com/ChrisTerBeke/homey-enphase/issues",
+  "homepage": "https://github.com/ChrisTerBeke/homey-enphase",
+  "bugs": {
+    "url": "https://github.com/ChrisTerBeke/homey-enphase/issues"
+  }
 }

--- a/app.json
+++ b/app.json
@@ -28,6 +28,12 @@
     "email": "contact+homey@christerbeke.com"
   },
   "brandColor": "#f37321",
+  "source": "https://github.com/ChrisTerBeke/homey-enphase",
+  "support": "https://github.com/ChrisTerBeke/homey-enphase/issues",
+  "homepage": "https://github.com/ChrisTerBeke/homey-enphase",
+  "bugs": {
+    "url": "https://github.com/ChrisTerBeke/homey-enphase/issues"
+  },
   "drivers": [
     {
       "id": "enphase_driver",

--- a/app.json
+++ b/app.json
@@ -84,7 +84,8 @@
           "id": "login_oauth2",
           "template": "login_oauth2"
         }
-      ]
+      ],
+      "energy": {}
     }
   ],
   "capabilities": {

--- a/app.ts
+++ b/app.ts
@@ -1,3 +1,7 @@
+import sourceMapSupport from 'source-map-support'
+sourceMapSupport.install()
+
+// @ts-ignore 80005 homey-oauth2app does not have type declarations
 const { OAuth2App } = require('homey-oauth2app')
 import { EnphaseOAuth2Client } from './lib/EnphaseOAuth2Client'
 

--- a/drivers/enphase_driver/device.ts
+++ b/drivers/enphase_driver/device.ts
@@ -1,6 +1,7 @@
 const { OAuth2Device } = require('homey-oauth2app')
 
-const POLL_INTERVAL_MS = 1000 * 60 * 5
+// Enphase Cloud data is updated every 15 minutes by Envoy
+const POLL_INTERVAL_MS = 1000 * 60 * 15
 
 class EnphaseEnvoyDevice extends OAuth2Device {
 

--- a/drivers/enphase_driver/device.ts
+++ b/drivers/enphase_driver/device.ts
@@ -1,3 +1,4 @@
+// @ts-ignore 80005 homey-oauth2app does not have type declarations
 const { OAuth2Device } = require('homey-oauth2app')
 
 // Enphase Cloud data is updated every 15 minutes by Envoy

--- a/drivers/enphase_driver/driver.compose.json
+++ b/drivers/enphase_driver/driver.compose.json
@@ -47,5 +47,6 @@
       "id": "login_oauth2",
       "template": "login_oauth2"
     }
-  ]
+  ],
+  "energy": {}
 }

--- a/drivers/enphase_driver/driver.ts
+++ b/drivers/enphase_driver/driver.ts
@@ -1,3 +1,4 @@
+// @ts-ignore 80005 homey-oauth2app does not have type declarations
 const { OAuth2Driver } = require('homey-oauth2app')
 import { EnphaseOAuth2Client } from '../../lib/EnphaseOAuth2Client'
 

--- a/lib/EnphaseOAuth2Client.ts
+++ b/lib/EnphaseOAuth2Client.ts
@@ -122,19 +122,23 @@ export class EnphaseOAuth2Client extends OAuth2Client {
 
     async getSystems(): Promise<SystemsResponse> {
         return await this.get({
-            path: `/systems?key=${Homey.env.API_KEY}`,
+            path: `/systems${this.generateQueryString()}`,
         })
     }
 
     async getSystemSummary(systemId: string): Promise<SystemSummaryResponse> {
         return await this.get({
-            path: `/systems/${systemId}/summary?key=${Homey.env.API_KEY}`,
+            path: `/systems/${systemId}/summary${this.generateQueryString()}`,
         })
     }
 
     async getSystemDevices(systemId: string): Promise<SystemDevicesResponse> {
         return await this.get({
-            path: `/systems/${systemId}/devices?key=${Homey.env.API_KEY}`,
+            path: `/systems/${systemId}/devices${this.generateQueryString()}`,
         })
+    }
+
+    generateQueryString() {
+        return `?key=${Homey.env.API_KEY}`
     }
 }

--- a/lib/EnphaseOAuth2Client.ts
+++ b/lib/EnphaseOAuth2Client.ts
@@ -24,6 +24,60 @@ export type SystemSummaryResponse = {
     last_report_at: number
 }
 
+export type SystemDevicesResponse = {
+    system_id: number
+    total_devices: number
+    devices: {
+        micros: Micro[]
+        gateways: Gateway[]
+        q_relays: Relay[]
+    }
+}
+
+export type Micro = {
+    id: number
+    last_report_at: number
+    name: string
+    serial_number: string
+    part_number: string
+    sku: string
+    model: string
+    status: string
+    active: boolean
+}
+
+export type Gateway = {
+    id: number
+    last_report_at: number
+    name: string
+    serial_number: string
+    part_number: string
+    emu_sw_version: string
+    sku: string
+    model: string
+    status: string
+    active: boolean
+    cellular_modem: {
+        imei: string
+        part_num: string
+        sku: string
+        plan_start_date: number
+        plan_end_date: number
+    }
+}
+
+export type Relay = {
+    id: number
+    last_report_at: number
+    name: string
+    serial_number: string
+    part_number: string
+    sku: string
+    model: string
+    status: string
+    active: boolean
+}
+
 export class EnphaseOAuth2Client extends OAuth2Client {
 
     static API_URL = 'https://api.enphaseenergy.com/api/v4'
@@ -75,6 +129,12 @@ export class EnphaseOAuth2Client extends OAuth2Client {
     async getSystemSummary(systemId: string): Promise<SystemSummaryResponse> {
         return await this.get({
             path: `/systems/${systemId}/summary?key=${Homey.env.API_KEY}`,
+        })
+    }
+
+    async getSystemDevices(systemId: string): Promise<SystemDevicesResponse> {
+        return await this.get({
+            path: `/systems/${systemId}/devices?key=${Homey.env.API_KEY}`,
         })
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "com.christerbeke.homey-enphase",
       "version": "0.0.1",
       "dependencies": {
-        "homey-oauth2app": "^3.5.0"
+        "homey-oauth2app": "^3.5.0",
+        "source-map-support": "^0.5.21"
       },
       "devDependencies": {
         "@tsconfig/node12": "^1.0.11",
-        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1",
-        "@types/node": "^18.11.3",
+        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3",
+        "@types/node": "^18.13.0",
+        "@types/source-map-support": "^0.5.6",
         "eslint": "^7.32.0",
         "eslint-config-athom": "^3.1.1",
         "typescript": "^4.8.4"
@@ -205,9 +207,9 @@
     },
     "node_modules/@types/homey": {
       "name": "homey-apps-sdk-v3-types",
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.1.tgz",
-      "integrity": "sha512-4W4YW/ib4hK7zC6vQT1ryfySJ2GOuite7cKmYRZ4BuGgwYweIOMwZLTJ+iZBWy11Ni/Pl3Tnp/pQD+qJJCcdyg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.3.tgz",
+      "integrity": "sha512-HGvjGhGqIrRgrJgucEK1+Arl/7f8EtFeOtIjnWQfl2fnreVGz3hkgu4j7Nl2SER/BTnUSSdiHceZETsgVl491Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^14.14.20"
@@ -232,9 +234,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -242,6 +244,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
       "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
       "dev": true
+    },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.40.1",
@@ -626,6 +637,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -2465,6 +2481,23 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2950,9 +2983,9 @@
       "dev": true
     },
     "@types/homey": {
-      "version": "npm:homey-apps-sdk-v3-types@0.3.1",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.1.tgz",
-      "integrity": "sha512-4W4YW/ib4hK7zC6vQT1ryfySJ2GOuite7cKmYRZ4BuGgwYweIOMwZLTJ+iZBWy11Ni/Pl3Tnp/pQD+qJJCcdyg==",
+      "version": "npm:homey-apps-sdk-v3-types@0.3.3",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.3.tgz",
+      "integrity": "sha512-HGvjGhGqIrRgrJgucEK1+Arl/7f8EtFeOtIjnWQfl2fnreVGz3hkgu4j7Nl2SER/BTnUSSdiHceZETsgVl491Q==",
       "dev": true,
       "requires": {
         "@types/node": "^14.14.20"
@@ -2979,9 +3012,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "@types/semver": {
@@ -2989,6 +3022,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
       "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
       "dev": true
+    },
+    "@types/source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.0"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.40.1",
@@ -3230,6 +3272,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -4566,6 +4613,20 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.1",
   "main": "app.ts",
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint --ext .js,.ts --ignore-path .gitignore ."
+    "start": "homey app run",
+    "build": "homey app build",
+    "lint": "eslint --ext .js,.ts --ignore-path .gitignore .",
+    "test": "homey app validate"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.11",
-    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1",
-    "@types/node": "^18.11.3",
+    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.3",
+    "@types/node": "^18.13.0",
+    "@types/source-map-support": "^0.5.6",
     "eslint": "^7.32.0",
     "eslint-config-athom": "^3.1.1",
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "homey-oauth2app": "^3.5.0"
+    "homey-oauth2app": "^3.5.0",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
The free developer plan of Enphase only allows for 1000 API calls per month. This PR reduces the amount of API calls being done to prevent hitting the limit too quickly.

To do:
* No API calls between sunset and sunrise (since there is no solar production then anyways)